### PR TITLE
feat: added missing events and actions docs of legend(selectall & inverseselect).

### DIFF
--- a/en/api/action.md
+++ b/en/api/action.md
@@ -92,6 +92,28 @@ dispatchAction({
 
 **EVENT:** [legendselectchanged](~events.legendselectchanged)
 
+### legendAllSelect(Action)
+Selects all legends.
+
+```js
+dispatchAction({
+    type: 'legendAllSelect'
+})
+```
+
+**EVENT:** [legendselectall](~events.legendselectall)
+
+### legendInverseSelect(Action)
+Unselects all legends.
+
+```js
+dispatchAction({
+    type: 'legendInverseSelect'
+})
+```
+
+**EVENT:** [legendinverseselect](~events.legendinverseselect)
+
 ### legendScroll(Action)
 Controll the scrolling of legend. It works when [legend.type](option.html#legend.type) is `'scroll'`.
 ```js

--- a/en/api/action.md
+++ b/en/api/action.md
@@ -104,7 +104,7 @@ dispatchAction({
 **EVENT:** [legendselectall](~events.legendselectall)
 
 ### legendInverseSelect(Action)
-Unselects all legends.
+Inverses all legends.
 
 ```js
 dispatchAction({

--- a/en/api/events.md
+++ b/en/api/events.md
@@ -139,7 +139,7 @@ Event emitted after all legends are selected.
 
 ## legendinverseselect(Event)
 **ACTION:** [legendInverseSelect](~action.legend.legendInverseSelect)
-Event emitted after unselecting all legends.
+Event emitted after inversing all legends.
 
 ```js
 {

--- a/en/api/events.md
+++ b/en/api/events.md
@@ -124,6 +124,32 @@ Event emitted after unselecting legend.
 }
 ```
 
+## legendselectall(Event)
+**ACTION:** [legendAllSelect](~action.legend.legendAllSelect)
+Event emitted after all legends are selected.
+
+```js
+{
+    type: 'legendselectall',
+    // table of all legend selecting states
+    selected: Object
+}
+```
+
+
+## legendinverseselect(Event)
+**ACTION:** [legendInverseSelect](~action.legend.legendInverseSelect)
+Event emitted after unselecting all legends.
+
+```js
+{
+    type: 'legendinverseselect',
+    // table of all legend selecting states
+    selected: Object
+}
+```
+
+
 ## legendscroll(Event)
 **ACTION:** [legendscroll](~action.legend.legendScroll)
 Event when trigger legend scroll.

--- a/zh/api/action.md
+++ b/zh/api/action.md
@@ -92,6 +92,26 @@ dispatchAction({
 
 **EVENT:** [legendselectchanged](~events.legendselectchanged)
 
+### legendAllSelect(Action)
+将图例全选。
+```js
+dispatchAction({
+    type: 'legendAllSelect'
+})
+```
+
+**EVENT:** [legendselectall](~events.legendselectall)
+
+### legendInverseSelect(Action)
+将图例反选。
+```js
+dispatchAction({
+    type: 'legendInverseSelect'
+})
+```
+
+**EVENT:** [legendinverseselect](~events.legendinverseselect)
+
 ### legendScroll(Action)
 控制图例的滚动。当 [legend.type](option.html#legend.type) 为 `'scroll'` 时有效。
 ```js

--- a/zh/api/events.md
+++ b/zh/api/events.md
@@ -123,6 +123,32 @@ chart.on('mouseover', {seriesIndex: 1, name: 'xx'}, function (params) {
 ```
 
 
+## legendselectall(Event)
+**ACTION:** [legendAllSelect](~action.legend.legendAllSelect)
+图例全选后的事件。
+
+```js
+{
+    type: 'legendselectall',
+    // 所有图例的选中状态表。
+    selected: Object
+}
+```
+
+
+## legendinverseselect(Event)
+**ACTION:** [legendInverseSelect](~action.legend.legendInverseSelect)
+图例反选后的事件。
+
+```js
+{
+    type: 'legendinverseselect',
+    // 所有图例的选中状态表。
+    selected: Object
+}
+```
+
+
 ## legendscroll(Event)
 **ACTION:** [legendscroll](~action.legend.legendScroll)
 图例滚动事件。


### PR DESCRIPTION
Currently, events(`legendselectall` & `legendinverseselect`) and actions(`legendAllSelect` & `legendInverseSelect`) are missing in `legend` component.

Added them according to https://github.com/apache/incubator-echarts/blob/master/src/component/legend/legendAction.js#L82-L90