### PR TITLE
fix: added missing properties(name/seriesType) in some series.

### DIFF
--- a/en/option/partial/mark-point.md
+++ b/en/option/partial/mark-point.md
@@ -4,6 +4,8 @@
 Mark point in a chart.
 
 {{ use:partial-symbol(
+    name=${name},
+    seriesType=${seriesType},
     defaultSymbol="'pin'",
     defaultSymbolSize=50,
     prefix="#" + ${prefix},
@@ -101,7 +103,9 @@ Y position according to container, in pixel.
 Label value, which can be ignored.
 
 {{ use:partial-symbol(
-    prefix="##" + ${prefix}
+    prefix="##" + ${prefix},
+    seriesType=${seriesType},
+    name=${name}
 ) }}
 
 ###${prefix} itemStyle(Object)

--- a/en/option/partial/marker.md
+++ b/en/option/partial/marker.md
@@ -6,7 +6,8 @@
     seriesType=${seriesType},
     hasCoord=${hasCoord},
     hasType=${hasType},
-    galleryEditorPath=${galleryEditorPath}
+    galleryEditorPath=${galleryEditorPath},
+    name=${name}
 )}}prefix
 {{use: partial-mark-line(
     prefix=${prefix},

--- a/en/option/series/bar.md
+++ b/en/option/series/bar.md
@@ -151,7 +151,8 @@ The style setting of the text label in a single bar.
     galleryEditorPath=${galleryEditorPath},
     seriesType="bar",
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use:partial-clip(

--- a/en/option/series/boxplot.md
+++ b/en/option/series/boxplot.md
@@ -175,7 +175,8 @@ Value of data item.
     seriesType="boxplot",
     galleryEditorPath=${galleryEditorPath},
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use:partial-z-zlevel(

--- a/en/option/series/candlestick.md
+++ b/en/option/series/candlestick.md
@@ -201,7 +201,8 @@ Emphasis style of a candle box.
     seriesType="candlestick",
     galleryEditorPath=${galleryEditorPath},
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use: partial-clip(

--- a/en/option/series/effectScatter.md
+++ b/en/option/series/effectScatter.md
@@ -49,6 +49,8 @@ The brush type for ripples. options: `'stroke'` and `'fill'`.
 )}}
 
 {{ use:partial-symbol(
+    name="effectScatter",
+    seriesType="effectScatter",
     defaultSymbol="'circle'",
     defaultSymbolSize=10,
     prefix="#",
@@ -110,6 +112,7 @@ The brush type for ripples. options: `'stroke'` and `'fill'`.
 ) }}
 
 {{ use:partial-symbol(
+    seriesType="effectScatter",
     defaultSymbol="'circle'",
     defaultSymbolSize=4,
     prefix="##",
@@ -144,7 +147,8 @@ The brush type for ripples. options: `'stroke'` and `'fill'`.
     prefix="#",
     seriesType="effectScatter",
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 

--- a/en/option/series/funnel.md
+++ b/en/option/series/funnel.md
@@ -162,7 +162,8 @@ The label configuration of a single data item.
 {{use: partial-marker(
     prefix="#",
     galleryEditorPath=${galleryEditorPath},
-    seriesType="funnel"
+    seriesType="funnel",
+    name="mark point"
 )}}
 
 {{use:partial-animation(prefix="#")}}

--- a/en/option/series/gauge.md
+++ b/en/option/series/gauge.md
@@ -189,7 +189,8 @@ The text color. Defaults to use [the color of section](~series-gauge.axisLine.li
 {{use: partial-marker(
     prefix="#",
     galleryEditorPath=${galleryEditorPath},
-    seriesType="gauge"
+    seriesType="gauge",
+    name="mark point"
 )}}
 
 {{use:partial-animation(prefix="#")}}

--- a/en/option/series/graph.md
+++ b/en/option/series/graph.md
@@ -336,7 +336,8 @@ Alias of [links](~series-graph.links)
     prefix="#",
     seriesType="graph",
     hasType=true,
-    hasCoord=true
+    hasCoord=true,
+    name="mark point"
 )}}
 
 {{ use: partial-rect-layout-width-height(

--- a/en/option/series/heatmap.md
+++ b/en/option/series/heatmap.md
@@ -106,7 +106,8 @@ Style of a single data point. It is valid with [coordinateSystem](~series-heatma
 {{use: partial-marker(
     prefix="#",
     galleryEditorPath=${galleryEditorPath},
-    seriesType="heatmap"
+    seriesType="heatmap",
+    name="mark point"
 )}}
 
 {{use:partial-z-zlevel(

--- a/en/option/series/line.md
+++ b/en/option/series/line.md
@@ -31,7 +31,8 @@ Broken line chart relates all the data points [symbol](~series-line.symbol) by b
     defaultSymbol="'circle'",
     defaultSymbolSize=4,
     prefix="#",
-    hasCallback=true
+    hasCallback=true,
+    name="line point"
 ) }}
 
 ## showSymbol(boolean) = true
@@ -206,7 +207,8 @@ The style of the symbol of single data point.
     galleryEditorPath=${galleryEditorPath},
     seriesType="line",
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use:partial-z-zlevel(

--- a/en/option/series/lines.md
+++ b/en/option/series/lines.md
@@ -159,7 +159,8 @@ The line style of this data item.
 {{use: partial-marker(
     prefix="#",
     galleryEditorPath=${galleryEditorPath},
-    seriesType="lines"
+    seriesType="lines",
+    name="mark point"
 )}}
 
 {{use:partial-clip(

--- a/en/option/series/map.md
+++ b/en/option/series/map.md
@@ -108,7 +108,8 @@ Area color in the map.
     prefix="#",
     seriesType="map",
     galleryEditorPath=${galleryEditorPath},
-    hasCoord=true
+    hasCoord=true,
+    name="mark point"
 )}}
 
 {{ use:partial-silent(

--- a/en/option/series/pictorialBar.md
+++ b/en/option/series/pictorialBar.md
@@ -165,7 +165,8 @@ The style setting of the text label in a single bar.
     galleryEditorPath=${galleryEditorPath},
     seriesType="pictorialBar",
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use:partial-z-zlevel(

--- a/en/option/series/pie.md
+++ b/en/option/series/pie.md
@@ -228,7 +228,8 @@ The label configuration of a single sector.
 {{use: partial-marker(
     prefix="#",
     galleryEditorPath=${galleryEditorPath},
-    seriesType="pie"
+    seriesType="pie",
+    name="mark point"
 )}}
 
 {{ use:partial-silent(

--- a/en/option/series/radar.md
+++ b/en/option/series/radar.md
@@ -21,6 +21,7 @@ Here is the example of AQI data which is presented in radar chart.
 Index of [radar](~radar) component that radar chart uses.
 
 {{ use:partial-symbol(
+    name="radar",
     seriesType="radar",
     defaultSymbol="'circle'",
     defaultSymbolSize=4,

--- a/en/option/series/scatter.md
+++ b/en/option/series/scatter.md
@@ -28,6 +28,7 @@ Whether to enable the animation effect when mouse is on the symbol.
 {{ use: partial-legend-hover-link }}
 
 {{ use:partial-symbol(
+    name="scatter",
     seriesType="scatter",
     defaultSymbol="'circle'",
     defaultSymbolSize=10,
@@ -134,7 +135,8 @@ the style setting about single data point(bubble).
     galleryEditorPath=${galleryEditorPath},
     seriesType="scatter",
     hasCoord=true,
-    hasType=true
+    hasType=true,
+    name="mark point"
 )}}
 
 {{use:partial-clip(

--- a/en/option/series/tree.md
+++ b/en/option/series/tree.md
@@ -57,7 +57,8 @@ The direction of the `orthogonal` layout in the tree diagram. That means this co
     defaultSymbol="'emptyCircle'",
     defaultSymbolSize=7,
     prefix="#",
-    hasCallback=true
+    hasCallback=true,
+    name="tree node"
 ) }}
 
 

--- a/zh/option/partial/mark-point.md
+++ b/zh/option/partial/mark-point.md
@@ -4,10 +4,12 @@
 图表标注。
 
 {{ use:partial-symbol(
+    seriesType=${seriesType},
     defaultSymbol="'pin'",
     defaultSymbolSize=50,
     prefix="#" + ${prefix},
-    hasCallback=true
+    hasCallback=true,
+    name=${name}
 ) }}
 
 {{ use: partial-silent(prefix="#" + ${prefix}) }}
@@ -105,7 +107,8 @@ data: [{{if: ${hasType} }}
 标注值，可以不设。
 
 {{ use:partial-symbol(
-    prefix="##" + ${prefix}
+    prefix="##" + ${prefix},
+    seriesType=${seriesType}
 ) }}
 
 ###${prefix} itemStyle(Object)

--- a/zh/option/partial/marker.md
+++ b/zh/option/partial/marker.md
@@ -6,7 +6,8 @@
     seriesType=${seriesType},
     hasCoord=${hasCoord},
     hasType=${hasType},
-    galleryEditorPath=${galleryEditorPath}
+    galleryEditorPath=${galleryEditorPath},
+    name=${name}
 )}}
 {{use: partial-mark-line(
     prefix=${prefix},

--- a/zh/option/series/effectScatter.md
+++ b/zh/option/series/effectScatter.md
@@ -46,6 +46,7 @@
 )}}
 
 {{ use:partial-symbol(
+    seriesType="effectScatter",
     defaultSymbol="'circle'",
     defaultSymbolSize=10,
     prefix="#",
@@ -110,6 +111,7 @@
 ) }}
 
 {{ use:partial-symbol(
+    seriesType="effectScatter",
     defaultSymbol="'circle'",
     defaultSymbolSize=4,
     prefix="##",


### PR DESCRIPTION
Some series are missing the `name` or `seriesType` property which brings a unexpected document description or a bad link.

![image](https://user-images.githubusercontent.com/26999792/82822964-44590d00-9ed9-11ea-8e9b-fe7859fb2cab.png)

![image](https://user-images.githubusercontent.com/26999792/82823135-9dc13c00-9ed9-11ea-8378-246e4131602a.png)
