### PR TITLE
fix: added missing option `axisLabel.distance` for Gauge series.

### DIFF
--- a/en/option/series/gauge.md
+++ b/en/option/series/gauge.md
@@ -97,6 +97,8 @@ The length of tick line, can be a pecentage value relative to radius.
 Axis tick label.
 ### show(boolean) = true
 Whether to show the label.
+### distance(number) = 5
+The distance between the label and tick line.
 ### formatter(string|Function)
 The content formatter of scale label, which supports both string template and callback function.
 Example:


### PR DESCRIPTION
Original Mail: https://lists.apache.org/thread.html/racf2a880dbdacbe85d6791f6c35e753a796c1ff3f0f1066769583d14%40%3Cdev.echarts.apache.org%3E