### PR TITLE
(WIP) fix: added missing option `legend.itemStyle`.

### DIFF
--- a/en/option/component/legend.md
+++ b/en/option/component/legend.md
@@ -118,6 +118,14 @@ selected: {
 }
 ```
 
+## itemStyle(Object)
+Legend symbol style.
+
+{{ use: partial-item-style(
+    componentName='legend',
+    prefix='##'
+) }}
+
 ## textStyle(Object)
 
 Legend text style.

--- a/zh/option/component/legend.md
+++ b/zh/option/component/legend.md
@@ -117,6 +117,14 @@ selected: {
 }
 ```
 
+## itemStyle(Object)
+图例的公用图形样式。
+
+{{ use: partial-item-style(
+    componentName='图例',
+    prefix='##'
+) }}
+
 ## textStyle(Object)
 
 图例的公用文本样式。
@@ -124,7 +132,7 @@ selected: {
 {{ use: partial-text-style(
     componentName='图例',
     prefix='##',
-    defaultColor="#333",
+    defaultColor='#333',
     noAlign=true,
     noVerticalAlign=true
 ) }}


### PR DESCRIPTION
`legend.itemStyle` is supported but it is missing in document.
See the demo: https://gallery.echartsjs.com/editor.html?c=x5ND27LCap&v=1