### PR TITLE
fix(sankey): added missing `name` option.

### DIFF
--- a/zh/option/series/sankey.md
+++ b/zh/option/series/sankey.md
@@ -28,7 +28,9 @@
 
 {{use: partial-component-id(prefix="#")}}
 
-{{ use: partial-rect-layout-width-height(
+{{use: partial-series-name()}}
+
+{{use: partial-rect-layout-width-height(
     componentName='sankey',
     defaultLeft: '5%',
     defaultRight: '20%',
@@ -36,7 +38,7 @@
     defaultBottom: '5%',
     defaultWidth: 'null',
     defaultHeight: 'null'
-) }}
+)}}
 
 ## nodeWidth(number) = 20
 


### PR DESCRIPTION
Related to #107.
Thanks to @softwords, he added the missing options (`name` & `nodeAlign`) into English document.
I found that [`nodeAlign`](https://echarts.apache.org/zh/option.html#series-sankey.nodeAlign) exsits but `name` is also missing in Chinese document, so I've created this PR to add it.