### PR TITLE
fix(axisPointer): change en to zh.

### DIFF
--- a/zh/option/component/axis-common.md
+++ b/zh/option/component/axis-common.md
@@ -532,7 +532,7 @@ data: [{
 {{if: !${noAxisPointer} }}
 #${prefix} axisPointer(Object)
 
-axisPointer settings on axis.
+坐标轴指示器配置项。
 
 {{ use: partial-axisPointer-common(
     prefix="#" + ${prefix},


### PR DESCRIPTION
Chinese document shouldn't display the English translation.

- https://echarts.apache.org/zh/option.html#xAxis.axisPointer
- https://echarts.apache.org/zh/option.html#yAxis.axisPointer

![image](https://user-images.githubusercontent.com/26999792/84863633-d05cef80-b0a7-11ea-94db-9caa65cf98f7.png)
