### PR TITLE
fix(gauge): added missing buttons in gauge example.

### DIFF
--- a/en/option/series/gauge.md
+++ b/en/option/series/gauge.md
@@ -6,7 +6,7 @@
 **Gauge chart**
 
 **Example: **
-~[600x500](${galleryViewPath}gauge-car)
+~[600x500](${galleryViewPath}gauge-car&reset=1&edit=1)
 
 ## type(string) = 'gauge'
 

--- a/zh/option/series/gauge.md
+++ b/zh/option/series/gauge.md
@@ -6,7 +6,7 @@
 **仪表盘**
 
 **示例：**
-~[600x500](${galleryViewPath}gauge-car)
+~[600x500](${galleryViewPath}gauge-car&reset=1&edit=1)
 
 ## type(string) = 'gauge'
 


### PR DESCRIPTION
Added missing buttons in gauge examples.
- https://echarts.apache.org/zh/option.html#series-gauge
- https://echarts.apache.org/en/option.html#series-gauge

Before
![image](https://user-images.githubusercontent.com/26999792/84998399-5cdbe080-b182-11ea-87d6-a8565720f9b5.png)

After
![image](https://user-images.githubusercontent.com/26999792/84998462-72510a80-b182-11ea-8dca-0e9208d0c971.png)
