### PR TITLE
Replace defualt with default (fixing typo)

### DIFF
--- a/en/api/echarts-instance.md
+++ b/en/api/echarts-instance.md
@@ -43,15 +43,15 @@ chart.setOption(option, {
 
 + `notMerge`
 
-    Optional; states whether not to merge with previous `option`; `false` by defualt, stating merging.
+    Optional; states whether not to merge with previous `option`; `false` by default, stating merging.
 
 + `lazyUpdate`
 
-    Optional; states whether not to update chart immediately; `false` by defualt, stating update immediately.
+    Optional; states whether not to update chart immediately; `false` by default, stating update immediately.
 
 + `silent`
 
-    Optional; states whether not to prevent triggering events when calling `setOption`; `false` by defualt, stating trigger events.
+    Optional; states whether not to prevent triggering events when calling `setOption`; `false` by default, stating trigger events.
 
 
 ## getWidth(Function)

--- a/en/option/component/toolbox.md
+++ b/en/option/component/toolbox.md
@@ -4,7 +4,7 @@
 The style setting of ${name} icon. Since icon label is displayed only when hovering on the icon, the label configuration options are available under `emphasis`.
 {{ use: partial-item-style(
     defaultBorderColor = '#666',
-    defualtColor = 'none',
+    defaultColor = 'none',
     defaultBorderWidth = 1,
     prefix="#" + ${prefix}
 ) }}

--- a/en/option/component/visual-map-piecewise.md
+++ b/en/option/component/visual-map-piecewise.md
@@ -186,7 +186,7 @@ The distance between the ends of the graphical elements for pieces and the label
 
 ## showLabel(boolean)
 
-Whether to show label of each item. By defualt, label will not be shown when [visualMap-piecewise.text](~visualMap-piecewise.text) used, otherwise label will be shown.
+Whether to show label of each item. By default, label will not be shown when [visualMap-piecewise.text](~visualMap-piecewise.text) used, otherwise label will be shown.
 
 ## itemGap = 10
 

--- a/en/option/component/visual-map.md
+++ b/en/option/component/visual-map.md
@@ -161,7 +161,7 @@ For instance, `[visualMap.min, visualMap.max]` is set to be `[0, 100]`, and ther
 
 We can also set the visual range inversely, such as `opacity: [1, 0.4]`, and the final mapping result for the given series.data above will be `[0.7, 0.96, 0.4]`.
 
-Notice: [visualMap.min, visualMap.max] should be set manually and is [0, 100] by defualt, but not `dataMin` and `dataMax` in series.data.
+Notice: [visualMap.min, visualMap.max] should be set manually and is [0, 100] by default, but not `dataMin` and `dataMax` in series.data.
 
 
 How to configure visualMap component to do Linear Mapping?
@@ -381,7 +381,7 @@ Use the last dimension of `data` by default.
 Specify visual mapping should be performed on which series, from which
 [series.data](~series.data) is fetched.
 
-All series are used by defualt.
+All series are used by default.
 
 
 ## hoverLink(boolean) = true

--- a/slides/ani/asset/common/echarts.min.js
+++ b/slides/ani/asset/common/echarts.min.js
@@ -37379,7 +37379,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	     *                                            visual data can be array or object
 	     *                                            (like: {cate1: '#222', none: '#fff'})
 	     *                                            or primary types (which represents
-	     *                                            defualt category visual), otherwise visual
+	     *                                            default category visual), otherwise visual
 	     *                                            can be array or primary (which will be
 	     *                                            normalized to array).
 	     *
@@ -38373,7 +38373,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        rect[wh[idx1WhenH]] -= rowOtherLength;
 	    }
 
-	    // Return [containerWidth, containerHeight] as defualt.
+	    // Return [containerWidth, containerHeight] as default.
 	    function estimateRootSize(seriesModel, targetInfo, viewRoot, containerWidth, containerHeight) {
 	        // If targetInfo.node exists, we zoom to the node,
 	        // so estimate whold width and heigth by target node.
@@ -48722,7 +48722,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                        isSetLoc(newElOption, ['left', 'right']), // Rigid body, dont care `width`.
 	                        isSetLoc(newElOption, ['top', 'bottom'])  // Rigid body, Dont care `height`.
 	                    ];
-	                    // Given defualt group size, otherwise may layout error.
+	                    // Given default group size, otherwise may layout error.
 	                    if (existList[index].type === 'group') {
 	                        existList[index].width == null && (existList[index].width = newElOption.width = 0);
 	                        existList[index].height == null && (existList[index].height = newElOption.height = 0);
@@ -58325,7 +58325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                // Originally we use visualMap.color as the default color, but setOption at
 	                // the second time the default color will be erased. So we change to use
 	                // constant DEFAULT_COLOR.
-	                // If user do not want the defualt color, set inRange: {color: null}.
+	                // If user do not want the default color, set inRange: {color: null}.
 	                base.inRange = base.inRange || {color: DEFAULT_COLOR};
 
 	                // If using shortcut like: {inRange: 'symbol'}, complete default value.

--- a/slides/arch-brief/asset/common/echarts.min.js
+++ b/slides/arch-brief/asset/common/echarts.min.js
@@ -37379,7 +37379,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	     *                                            visual data can be array or object
 	     *                                            (like: {cate1: '#222', none: '#fff'})
 	     *                                            or primary types (which represents
-	     *                                            defualt category visual), otherwise visual
+	     *                                            default category visual), otherwise visual
 	     *                                            can be array or primary (which will be
 	     *                                            normalized to array).
 	     *
@@ -38373,7 +38373,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        rect[wh[idx1WhenH]] -= rowOtherLength;
 	    }
 
-	    // Return [containerWidth, containerHeight] as defualt.
+	    // Return [containerWidth, containerHeight] as default.
 	    function estimateRootSize(seriesModel, targetInfo, viewRoot, containerWidth, containerHeight) {
 	        // If targetInfo.node exists, we zoom to the node,
 	        // so estimate whold width and heigth by target node.
@@ -48722,7 +48722,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                        isSetLoc(newElOption, ['left', 'right']), // Rigid body, dont care `width`.
 	                        isSetLoc(newElOption, ['top', 'bottom'])  // Rigid body, Dont care `height`.
 	                    ];
-	                    // Given defualt group size, otherwise may layout error.
+	                    // Given default group size, otherwise may layout error.
 	                    if (existList[index].type === 'group') {
 	                        existList[index].width == null && (existList[index].width = newElOption.width = 0);
 	                        existList[index].height == null && (existList[index].height = newElOption.height = 0);
@@ -58325,7 +58325,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                // Originally we use visualMap.color as the default color, but setOption at
 	                // the second time the default color will be erased. So we change to use
 	                // constant DEFAULT_COLOR.
-	                // If user do not want the defualt color, set inRange: {color: null}.
+	                // If user do not want the default color, set inRange: {color: null}.
 	                base.inRange = base.inRange || {color: DEFAULT_COLOR};
 
 	                // If using shortcut like: {inRange: 'symbol'}, complete default value.

--- a/slides/custom/asset/common/echarts.js
+++ b/slides/custom/asset/common/echarts.js
@@ -39955,7 +39955,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	     *                                            visual data can be array or object
 	     *                                            (like: {cate1: '#222', none: '#fff'})
 	     *                                            or primary types (which represents
-	     *                                            defualt category visual), otherwise visual
+	     *                                            default category visual), otherwise visual
 	     *                                            can be array or primary (which will be
 	     *                                            normalized to array).
 	     *
@@ -40988,7 +40988,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        rect[wh[idx1WhenH]] -= rowOtherLength;
 	    }
 
-	    // Return [containerWidth, containerHeight] as defualt.
+	    // Return [containerWidth, containerHeight] as default.
 	    function estimateRootSize(seriesModel, targetInfo, viewRoot, containerWidth, containerHeight) {
 	        // If targetInfo.node exists, we zoom to the node,
 	        // so estimate whold width and heigth by target node.
@@ -51718,7 +51718,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            symbolPosition: null, // 'start' or 'end' or 'center', null means auto.
 	            symbolOffset: null,
 	            symbolMargin: null,   // start margin and end margin. Can be a number or a percent string.
-	                                  // Auto margin by defualt.
+	                                  // Auto margin by default.
 	            symbolRepeat: false,  // false/null/undefined, means no repeat.
 	                                  // Can be true, means auto calculate repeat times and cut by data.
 	                                  // Can be a number, specifies repeat times, and do not cut by data.
@@ -53503,7 +53503,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var snapToValue = payloadInfo.snapToValue;
 
 	        // Fill content of event obj for echarts.connect.
-	        // By defualt use the first involved series data as a sample to connect.
+	        // By default use the first involved series data as a sample to connect.
 	        if (payloadBatch[0] && outputFinder.seriesIndex == null) {
 	            zrUtil.extend(outputFinder, payloadBatch[0]);
 	        }
@@ -67356,7 +67356,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                // Originally we use visualMap.color as the default color, but setOption at
 	                // the second time the default color will be erased. So we change to use
 	                // constant DEFAULT_COLOR.
-	                // If user do not want the defualt color, set inRange: {color: null}.
+	                // If user do not want the default color, set inRange: {color: null}.
 	                base.inRange = base.inRange || {color: DEFAULT_COLOR};
 
 	                // If using shortcut like: {inRange: 'symbol'}, complete default value.

--- a/zh/option/component/toolbox.md
+++ b/zh/option/component/toolbox.md
@@ -4,7 +4,7 @@
 ${name} icon 样式设置。由于 icon 的文本信息只在 icon hover 时候才显示，所以文字相关的配置项请在 `emphasis` 下设置。
 {{ use: partial-item-style(
     defaultBorderColor = '#666',
-    defualtColor = 'none',
+    defaultColor = 'none',
     defaultBorderWidth = 1,
     prefix="#" + ${prefix}
 ) }}


### PR DESCRIPTION
This replaces a typo in the documentation, which sometimes lists "defualt" instead of default.

It's nothing major, really - just something i noticed while reading through the docs.

https://github.com/apache/incubator-echarts/pull/12828 does the same for code-comments.