### PR TITLE
fix(gauge): added missing colon in option of Gauge Series, which leads the losing of `legendHoverLink`.

### DIFF
--- a/en/option/series/gauge.md
+++ b/en/option/series/gauge.md
@@ -19,7 +19,7 @@
 ## radius(number|string) = '75%'
 The radius of gauge chart. It can be a percentage value of the smaller of container half width and half height, also can be an absolute value.
 
-{{ use partial-legend-hover-link }}
+{{ use: partial-legend-hover-link }}
 
 ## startAngle(number) = 225
 The start angle of gauge chart. The direct right side of [circle center](~series-gauge.center) is `0` degree, the right above it is `90` degree, the direct left side of it is `180` degree.

--- a/zh/option/series/gauge.md
+++ b/zh/option/series/gauge.md
@@ -19,7 +19,7 @@
 ## radius(number|string) = '75%'
 仪表盘半径，可以是相对于容器高宽中较小的一项的一半的百分比，也可以是绝对的数值。
 
-{{ use partial-legend-hover-link }}
+{{ use: partial-legend-hover-link }}
 
 ## startAngle(number) = 225
 仪表盘起始角度。[圆心](~series-gauge.center) 正右手侧为`0`度，正上方为`90`度，正左手侧为`180`度。


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26999792/85197849-5f6f3f00-b316-11ea-840b-8b70a3823158.png)

![image](https://user-images.githubusercontent.com/26999792/85197858-73b33c00-b316-11ea-9fa2-ca02495facc4.png)
