### PR TITLE
fix(themeRiver): add 'name'

### DIFF
--- a/en/option/series/themeRiver.md
+++ b/en/option/series/themeRiver.md
@@ -24,6 +24,8 @@ What's more, the time attribute of the orinigal dataset would map to a single ti
 
 {{use: partial-component-id(prefix="#")}}
 
+{{ use: partial-series-name() }}
+
 {{ use: partial-rect-layout-width-height(
     componentName='thmemRiver',
     defaultLeft: '5%',

--- a/zh/option/series/themeRiver.md
+++ b/zh/option/series/themeRiver.md
@@ -24,6 +24,8 @@
 
 {{use: partial-component-id(prefix="#")}}
 
+{{ use: partial-series-name() }}
+
 {{ use: partial-rect-layout-width-height(
     componentName='thmemRiver',
     defaultLeft: '5%',


### PR DESCRIPTION
See comments here:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45354

themeriver is the last series that requires `name` to be added. Creating this link in documentation means it can be referred to from `index.d.ts`