### PR TITLE
tweak: show live example button and component only when doc is type of option/gl-option.

### DIFF
--- a/src/components/DocContent.vue
+++ b/src/components/DocContent.vue
@@ -27,7 +27,7 @@
                 ></DocContentItemCard>
             </div>
         </div>
-        <template v-if="!shared.isMobile">
+        <template v-if="showLiveExample">
             <LiveExample
                 v-if="shared.showOptionExample"
                 :isDownLayout="isExampleTopDownPlayout"
@@ -49,7 +49,7 @@ import {
     getOutlineNode,
     getDefaultPage
 } from '../docHelper';
-import {store, getPagePath} from '../store';
+import {store, getPagePath, isOptionDoc} from '../store';
 import {directTo} from '../route';
 import DocContentItemCard from './DocContentItemCard.vue'
 import scrollIntoView from 'scroll-into-view';
@@ -113,6 +113,10 @@ export default {
             else {
                 return getOutlineNode(getPagePath());
             }
+        },
+
+        showLiveExample() {
+            return !this.shared.isMobile && isOptionDoc();
         }
     },
 

--- a/tool/md2json.js
+++ b/tool/md2json.js
@@ -349,7 +349,7 @@ function mdToJsonSchema(mdStr, maxDepth, imagePath, entry) {
         // Avoid marked converting the markers in the code unexpectly.
         // Like convert * to em.
         // Also no need to decode entity
-        if (entry === 'option') {
+        if (entry === 'option' || entry === 'option-gl') {
             section = section.replace(/(<\s*ExampleBaseOption[^>]*>)([\s\S]*?)(<\s*\/ExampleBaseOption\s*>)/g, function (text, openTag, code, closeTag) {
                 const codeKey = codeKeyPrefx + (codeIndex++);
                 codeMap[codeKey] = code;


### PR DESCRIPTION
- Don't show live example button and component if the doc is not the type of option and gl-option.
- Don't parse UI component if the doc is the type of option or gl-option.