### PR TITLE
feat: added support for changing the layout of option example preview panel.

### DIFF
--- a/en/option-gl/partial/shading.md
+++ b/en/option-gl/partial/shading.md
@@ -43,7 +43,7 @@ The configuration item of the realistic material is valid when [shading](~${comp
 The `roughness` attribute is used to indicate the roughness of the material, `0` is completely smooth, `1` is completely rough, and the middle value is between the two.
 
 {{ block: roughness-compare }}
-The following images show the effect of `roughness` in `globe](~globe) `0.2` (smooth) and `0.8` (rough).
+The following images show the effect of `roughness` in [`globe`](~globe) `0.2` (smooth) and `0.8` (rough).
 
 ![autox280](~globe-gloss.png)
 ![autox280](~globe-rough.png)

--- a/en/option-gl/partial/temporal-super-sampling.md
+++ b/en/option-gl/partial/temporal-super-sampling.md
@@ -16,4 +16,4 @@ The following is the difference between not opening `temporalSuperSampling` and 
 
 ##${prefix|default('#')} enable(boolean) = 'auto'
 
-Whether to enable temporal supersampling. By default, temporal supersampling is also turned on synchronously when [postEffect] (~${componentType}.postEffect) is turned on.
+Whether to enable temporal supersampling. By default, temporal supersampling is also turned on synchronously when [postEffect](~${componentType}.postEffect) is turned on.

--- a/src/components/LiveExample.vue
+++ b/src/components/LiveExample.vue
@@ -1,5 +1,5 @@
 <template>
-<div id="example-panel" :class="[isDownLayout ? 'down-layout' : 'right-layout']">
+<div id="example-panel" :class="shared.computedOptionExampleLayout + '-layout'">
     <h2>{{$t('example.title')}}</h2>
     <p class="intro">{{ shared.allOptionExamples ? $t('example.intro') : $t('example.noExample')}}</p>
     <div class="preview-and-code" v-if="shared.currentExampleOption">
@@ -23,9 +23,38 @@
                 :label="shared.locale === 'en' ? item['title-en'] : item.title"
             ></el-option>
         </el-select>
-        <el-button v-if="shared.currentExampleOption" type="primary" icon="el-icon-refresh" size="mini" @click="refreshForce">{{$t('example.refresh')}}</el-button>
+        <el-button v-if="shared.currentExampleOption" 
+            type="primary" 
+            icon="el-icon-refresh" 
+            size="mini" 
+            :title="$t('example.refresh')"
+            @click="refreshForce"></el-button>
+        <el-button 
+            style="margin-left: 0"
+            type="primary" 
+            icon="el-icon-s-operation" 
+            size="mini" 
+            :title="$t('example.changeLayout')"
+            v-popover:changeLayoutPopover></el-button>
         <el-button size='mini' circle icon="el-icon-close" @click="closeExamplePanel"></el-button>
     </div>
+    <el-popover
+        ref="changeLayoutPopover"
+        placement="bottom"
+        trigger="click"
+        v-model="showChangeLayoutPopover">
+        <div class="example-change-layout">
+            <div class="layout-title"><i class="el-icon-s-operation"></i>{{$t('example.changeLayout')}}</div>
+            <div class="layout-mode">
+                <el-radio-group v-model="shared.optionExampleLayout" @change="changeLayout" size="mini">
+                    <el-radio-button 
+                        v-for="layout in optionExampleLayouts" 
+                        :key="layout" 
+                        :label="layout">{{$t('example.layout.' + layout)}}</el-radio-button>
+                </el-radio-group>
+            </div>
+        </div>
+    </el-popover>
 </div>
 </template>
 
@@ -34,7 +63,7 @@
 // Remarks:
 // 代码不能编辑，可以跳转到 examples 带上 base64，在 examples 页面编辑
 
-import {store, getPagePath} from '../store';
+import {store, getPagePath, updateOptionExampleLayout, optionExampleLayouts} from '../store';
 import CodeMirror from 'codemirror';
 import 'codemirror/lib/codemirror.css';
 // import 'codemirror/theme/paraiso-dark.css';
@@ -182,8 +211,6 @@ function updateOption(option, isRefreshForce) {
 
 export default {
 
-    props: ['isDownLayout'],
-
     data() {
         return {
             shared: store,
@@ -192,7 +219,11 @@ export default {
 
             lastUpdateExampleName: '',
 
-            oldHighlightedLines: []
+            oldHighlightedLines: [],
+
+            showChangeLayoutPopover: false,
+
+            optionExampleLayouts
         };
     },
 
@@ -253,7 +284,7 @@ export default {
         resize() {
             const examplePanel = this.$el;
             const previewMain = examplePanel.querySelector('.preview-main');
-            if (this.isDownLayout) {
+            if (this.shared.computedOptionExampleLayout !== 'right') {
                 examplePanel.style.height = (window.innerHeight * 0.5 - 60) + 'px';
                 examplePanel.style.width = 'auto';
             }
@@ -298,6 +329,14 @@ export default {
                 console.error(e);
                 console.log(code);
             }
+        },
+
+        changeLayout(layout) {
+            this.showChangeLayoutPopover = false;
+            updateOptionExampleLayout(layout);
+            this.$nextTick(() => {
+                this.resize();
+            });
         }
     },
 
@@ -362,7 +401,7 @@ export default {
 
     .preview-and-code {
         position: absolute;
-        top: 90px;
+        top: 75px;
         bottom: 0;
         left: 0;
         right: 0;
@@ -373,7 +412,9 @@ export default {
         top: 0;
     }
     .preview-main {
+        padding: 0 10px;
         background: #fefefe;
+        box-sizing: border-box;
     }
 
     .example-code {
@@ -443,10 +484,10 @@ export default {
         }
     }
 
-    &.down-layout {
+    &.bottom-layout {
         left: 300px;
         bottom: 0;
-        right: 0;
+        right: 10px;
 
         .preview-main {
             width: 50%;
@@ -458,6 +499,36 @@ export default {
             height: 100%;
             float: left;
         }
+    }
+
+
+    &.top-layout {
+        left: 300px;
+        // dev
+        // top: 40px;
+        top: 50px;
+        right: 10px;
+
+        .preview-main {
+            width: 50%;
+            height: 100%;
+            float: left;
+        }
+        .example-code {
+            width: 50%;
+            height: 100%;
+            float: left;
+        }
+    }
+}
+
+.example-change-layout {
+    .layout-title > i {
+        font-size: 14px;
+        margin-right: 5px;
+    }
+    .layout-mode {
+        margin-top: 10px;
     }
 }
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -42,7 +42,14 @@ export default {
             setOptionError: 'Something Unexpected Happerns. Click refresh to try again!',
 
             refresh: 'Refresh',
-            close: 'Close'
+            close: 'Close',
+            changeLayout: 'Change Layout',
+            layout: {
+                auto: 'Auto',
+                right: 'Right',
+                top: 'Top',
+                bottom: 'Bottom'
+            }
         }
     },
     zh: {
@@ -88,7 +95,14 @@ export default {
             setOptionError: '发生了一些意料之外的错误，点击刷新再试试！',
 
             refresh: '刷新',
-            close: '关闭'
+            close: '关闭',
+            changeLayout: '切换布局',
+            layout: {
+                auto: '自动',
+                right: '右侧',
+                top: '顶部',
+                bottom: '底部'
+            }
         }
     }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,35 @@
 import {getOutlineNode} from './docHelper';
 
+const OPTION_EXAMPLE_LAYOUT = '_ec_option_example_layout';
+
+export const optionExampleLayouts = ['auto', 'top', 'bottom', 'right'];
+
+export function updateOptionExampleLayout(layout) {
+    if (layout === 'auto') {
+        store.computedOptionExampleLayout = window.innerWidth < 1400 ? 'bottom' : 'right';
+    }
+    else {
+        store.computedOptionExampleLayout = layout;
+    }
+    store.optionExampleLayout = layout;
+    window.localStorage && window.localStorage.setItem(OPTION_EXAMPLE_LAYOUT, layout);
+}
+
+function getInitialOptionExampleLayout() {
+    const layout = {};
+    const savedLayout = window.localStorage && window.localStorage.getItem(OPTION_EXAMPLE_LAYOUT);
+    if (!savedLayout || savedLayout === 'auto' || optionExampleLayouts.indexOf(savedLayout) < 0) {
+        layout.mode = 'auto';
+        layout.computedMode = window.innerWidth < 1400 ? 'bottom' : 'right';
+    }
+    else {
+        layout.mode = layout.computedMode = savedLayout;
+    }
+    return layout;
+}
+
+const initialOptionExampleLayout = getInitialOptionExampleLayout();
+
 export const store = {
     docType: '',
 
@@ -19,7 +49,11 @@ export const store = {
     // Clear before setOption
     cleanMode: false,
     currentExampleName: '',
-    currentExampleOption: ''
+    currentExampleOption: '',
+    // Can be `top`, `bottom`, `right`, `auto`
+    optionExampleLayout: initialOptionExampleLayout.mode,
+    // Can be `top`, `bottom`, `right`
+    computedOptionExampleLayout: initialOptionExampleLayout.computedMode
 };
 
 export function getPagePath() {


### PR DESCRIPTION

![GIF](https://user-images.githubusercontent.com/26999792/86255199-671dc600-bbe9-11ea-9417-210fa28a8222.gif)


- Added support for changing the layout of the option example preview panel.
The valid value of layout can be `top`, `bottom`, `right` and `auto`.
By default, if the user never sets the layout manually, `auto` will be used. `auto` means that the panel will be at the bottom when the width of window is less than 1400px and otherwise it will be at the right.
And the browser will remember the layout settings by `localStorage` so that the user can continue to use the preferred layout later.

- Fixed some error links.