### PR TITLE
tweak: tweak live example layout style.

### DIFF
--- a/src/components/DocContent.vue
+++ b/src/components/DocContent.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="doc-main" v-loading="loading">
-        <div :class="[
+        <div ref="docContentDom"
+            :class="[
             'doc-content',
             shared.showOptionExample ? 'option-example-actived' : '',
             'option-example-' + shared.computedOptionExampleLayout + '-layout'
@@ -145,7 +146,10 @@ export default {
 
     methods: {
         resize() {
-           this.shared.optionExampleLayout === 'auto' && updateOptionExampleLayout('auto');
+            this.shared.optionExampleLayout === 'auto' && updateOptionExampleLayout('auto');
+            Vue.nextTick(() => {
+                this.updateDocContentMargin();
+            });
         },
 
         updateLazyload() {
@@ -241,12 +245,31 @@ export default {
 
         openOptionExample() {
             this.shared.showOptionExample = true;
+        },
+
+        updateDocContentMargin(isClose) {
+            if (!this.$refs.liveExample && !isClose) {
+                return;
+            }
+            // update margin of doc content
+            this.$refs.docContentDom.style.margin = '';
+            if (!isClose) {
+                const marginDir = this.shared.computedOptionExampleLayout;
+                if (marginDir !== 'right') {
+                    const marginStyleName = 'margin' + marginDir[0].toUpperCase() + marginDir.slice(1);
+                    const marginValue = this.$refs.liveExample.$el.clientHeight;
+                    this.$refs.docContentDom.style[marginStyleName] = marginValue + 'px';
+                }
+            }
         }
     },
 
     watch: {
         'shared.currentPath'(newVal) {
             this.updateCurrentPath(newVal);
+            Vue.nextTick(() => {
+                this.updateDocContentMargin();
+            });
         },
         'pageExamples'(newVal) {
             // { code, title, name }
@@ -258,12 +281,16 @@ export default {
                 this.shared.allOptionExamples = null;
             }
         },
-        // 'shared.currentOptionExampleLayout'() {
-        //     this.scrollTo(this.shared.currentPath);
-        // },
-        // 'shared.showOptionExample'() {
-        //     this.scrollTo(this.shared.currentPath);
-        // }
+        'shared.computedOptionExampleLayout'() {
+            Vue.nextTick(() => {
+                this.updateDocContentMargin();
+            });
+        },
+        'shared.showOptionExample'(newVal) {
+            Vue.nextTick(() => {
+                this.updateDocContentMargin(!newVal);
+            });
+        }
     }
 }
 </script>
@@ -309,10 +336,10 @@ export default {
 
     &.option-example-actived {
         &.option-example-top-layout {
-            margin-top: 42%;
+           // margin-top: 42%;
         }
         &.option-example-bottom-layout {
-            margin-bottom: 42%;
+           // margin-bottom: 42%;
         }
         &.option-example-right-layout {
             margin-right: 45%;


### PR DESCRIPTION
Currently, when the layout of live example panel is `top` or `bottom`, using the margin with a percent value for doc content dom is not a bit suitable, since it's based on the width of parent element.
Here I'm trying to set manually the margin value of the doc content according to its real width or height when the path or window's size changed.

**Before**
![image](https://user-images.githubusercontent.com/26999792/87271074-bd9dd500-c504-11ea-90fc-de7b2df5c6bc.png)

**After**
![image](https://user-images.githubusercontent.com/26999792/87271111-d27a6880-c504-11ea-9407-ad1e6d160b65.png)
