### PR TITLE
fix: search result width

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -80,7 +80,8 @@ export default {
 }
 
 .el-autocomplete-suggestion.search-input-popper {
-    width: 300px!important;
+    min-width: 300px !important;
+    width: max-content !important;
     li {
         line-height: 28px;
         padding: 0 10px;

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -80,8 +80,8 @@ export default {
 }
 
 .el-autocomplete-suggestion.search-input-popper {
-    min-width: 300px !important;
-    width: max-content !important;
+    width: auto !important;
+    min-width: 300px;
     li {
         line-height: 28px;
         padding: 0 10px;


### PR DESCRIPTION
### before:
<img width=50% src='https://user-images.githubusercontent.com/25839518/90516462-9935b800-e196-11ea-8f36-0a29cf998158.png'>

### after:
<img width=50% src='https://user-images.githubusercontent.com/25839518/90516420-89b66f00-e196-11ea-85c3-92ae9675673c.png'>

The current search result‘s width minimum is 300px (same as before), and the maximum is the maximum width of the current result.