### PR TITLE
fix(live-preview): add `position: relative` to make its child DOM elements with absolute positioning layout correctly.

### DIFF
--- a/src/components/LiveExample.vue
+++ b/src/components/LiveExample.vue
@@ -413,6 +413,7 @@ export default {
         top: 0;
     }
     .preview-main {
+        position: relative;
         padding: 0 10px;
         background: #fefefe;
         box-sizing: border-box;


### PR DESCRIPTION
Such as `DataView`.

**Before**

![image](https://user-images.githubusercontent.com/26999792/91112496-d974c900-e6b5-11ea-938c-05a53d350a64.png)

**After**

![image](https://user-images.githubusercontent.com/26999792/91112509-e72a4e80-e6b5-11ea-9d13-64288e591c85.png)
