### PR TITLE
fix(radar): fix textStyle does not work bug.

### DIFF
--- a/en/option/component/radar.md
+++ b/en/option/component/radar.md
@@ -45,8 +45,6 @@ formatter: function (value, indicator) {
 }
 ```
 
-## textStyle(Object)
-
 {{ use: partial-text-style(
     prefix = '##',
     defaultColor = "'#333'",

--- a/zh/option/component/radar.md
+++ b/zh/option/component/radar.md
@@ -81,8 +81,6 @@ formatter: function (value, indicator) {
 }
 ```
 
-## textStyle(Object)
-
 {{ use: partial-text-style(
     prefix = '##',
     defaultColor = "'#333'",


### PR DESCRIPTION
This issue had reported by #131, but that seems to be not working.
According to the code in this line https://github.com/apache/incubator-echarts/blob/next/src/coord/radar/RadarModel.ts#L105,
maybe we need to remove the current `textStyle` node.

**Current**

![image](https://user-images.githubusercontent.com/26999792/97151779-f2c7ed80-17aa-11eb-8c95-013c102bdd06.png)

**After**

![image](https://user-images.githubusercontent.com/26999792/97151526-91a01a00-17aa-11eb-940d-4702b90c7502.png)
