### PR TITLE
fix: typo in dataset & data-transform

### DIFF
--- a/en/option/partial/data-transform.md
+++ b/en/option/partial/data-transform.md
@@ -1,7 +1,7 @@
 
 {{ target: partial-data-transform-tutorial-ref }}
 
-See the tutorial of [datat transform](tutorial.html#Data%20Transform).
+See the tutorial of [data transform](tutorial.html#Data%20Transform).
 
 
 

--- a/en/tutorial/dataset.md
+++ b/en/tutorial/dataset.md
@@ -551,7 +551,7 @@ In fact, setting data via [series.data](option.html#series.data) is not deprecat
 
 ## Data transform
 
-See [datat transform](~Data%20Transform).
+See [data transform](~Data%20Transform).
 
 
 ## Others

--- a/zh/option/partial/data-transform.md
+++ b/zh/option/partial/data-transform.md
@@ -1,7 +1,7 @@
 
 {{ target: partial-data-transform-tutorial-ref }}
 
-参见这个教程： [datat transform](tutorial.html#%E4%BD%BF%E7%94%A8%20transform%20%E8%BF%9B%E8%A1%8C%E6%95%B0%E6%8D%AE%E8%BD%AC%E6%8D%A2).
+参见这个教程： [data transform](tutorial.html#%E4%BD%BF%E7%94%A8%20transform%20%E8%BF%9B%E8%A1%8C%E6%95%B0%E6%8D%AE%E8%BD%AC%E6%8D%A2).
 
 
 

--- a/zh/tutorial/dataset.md
+++ b/zh/tutorial/dataset.md
@@ -536,7 +536,7 @@ ECharts 4 之前一直以来的数据声明方式仍然被正常支持，如果�
 
 ## 数据转换器（ data transform ）
 
-参见 [datat transform](~%E4%BD%BF%E7%94%A8%20transform%20%E8%BF%9B%E8%A1%8C%E6%95%B0%E6%8D%AE%E8%BD%AC%E6%8D%A2)。
+参见 [data transform](~%E4%BD%BF%E7%94%A8%20transform%20%E8%BF%9B%E8%A1%8C%E6%95%B0%E6%8D%AE%E8%BD%AC%E6%8D%A2)。
 
 ## 其他
 


### PR DESCRIPTION
fix typo in dataset & data-transform docs:
- `datat set` -> `data set`